### PR TITLE
fix path casing

### DIFF
--- a/lib/elements/Expression.js
+++ b/lib/elements/Expression.js
@@ -1,4 +1,4 @@
-import Node from './node';
+import Node from './Node';
 
 /**
  * @class

--- a/lib/elements/Statement.js
+++ b/lib/elements/Statement.js
@@ -1,4 +1,4 @@
-import Node from './node';
+import Node from './Node';
 
 /**
  * @class


### PR DESCRIPTION
When I was trying to run the tests.

Unrelated but I'm getting `Error: Cannot find module 'babel/register'` even though `mocha test lib --recursive --compilers js:babel/register` is correct.

Not sure why I had to do `./node_modules/babel-core/register` to make it work.