### PR TITLE
use babel parser

### DIFF
--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -1,4 +1,4 @@
-import {parse} from 'esprima-fb';
+import {parse} from 'babel-jscs';
 import {buildTokenList, buildElementTree} from './elementTree';
 
 export default class Parser {

--- a/lib/Parser.js
+++ b/lib/Parser.js
@@ -6,14 +6,14 @@ export default class Parser {
 
     }
 
-    parse(code) {
-        var tree = this._parseAst(code);
+    parse(code, mode) {
+        var tree = this._parseAst(code, mode);
         var tokens = this._processTokens(tree, code);
         return buildElementTree(tree, tokens);
     }
 
-    _parseAst(code) {
-        return parse(code, {comment: true, tokens: true, range: true});
+    _parseAst(code, mode) {
+        return parse(code, mode);
     }
 
     _processTokens(tree, code) {

--- a/lib/elementTree.js
+++ b/lib/elementTree.js
@@ -69,7 +69,7 @@ const visitorKeys = {
     /*--*/ TemplateLiteral: ['quasis', 'expressions'],
     /*IT*/ ThisExpression: [],
     /*IT*/ ThrowStatement: ['argument'],
-    /*IT*/ TryStatement: ['block', 'handlers' /* esprima has handerS, not handler */, 'finalizer'], // https://github.com/estree/estree/blob/master/spec.md#trystatement
+    /*IT*/ TryStatement: ['block', 'handlers' /* esprima has handlerS, not handler */, 'handler', 'finalizer'], // https://github.com/estree/estree/blob/master/spec.md#trystatement
     /*IT*/ UnaryExpression: ['argument'],
     /*IT*/ UpdateExpression: ['argument'],
     /*IT*/ VariableDeclaration: ['declarations'],

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   "devDependencies": {
     "babel": "^5.5.8",
     "babel-core": "^5.5.5",
+    "babel-jscs": "^1.0.1",
     "benchmark": "^1.0.0",
     "chai": "^3.0.0",
     "chalk": "^1.0.0",

--- a/test/integrated/requireCurlyBraces.js
+++ b/test/integrated/requireCurlyBraces.js
@@ -56,7 +56,7 @@ let exceptions = {
 
 describe('integrated/requireCurlyBraces', () => {
     it('should add curly braces to all supported statements', () => {
-        let program = parseAndGetProgram(sourceCode);
+        let program = parseAndGetProgram(sourceCode, 'loose');
         for (var typeName in types) {
             for (let node of program.selectNodesByType(typeName)) {
                 for (let propName of types[typeName]) {

--- a/test/lib/elements/types/Literal.js
+++ b/test/lib/elements/types/Literal.js
@@ -22,7 +22,7 @@ describe('Literal', () => {
 
     it('should accept string escapes', () => {
         var value = '" \\" \\n \\r \\t \\f \\b \\v \\0 \\\n \\u006F \\251 \\xa9 \\u{000000000061} "';
-        var expression = parseAndGetExpression(value);
+        var expression = parseAndGetExpression(value, 'loose');
         expect(expression.type).to.equal('Literal');
         expect(expression.value).to.equal(' " \n \r \t \f \b \u000b \0  o © © a ');
         expect(expression.raw).to.equal(value);

--- a/test/lib/elements/types/UnaryExpression.js
+++ b/test/lib/elements/types/UnaryExpression.js
@@ -1,4 +1,4 @@
-import {parseAndGetExpression, parseLooseAndGetExpression} from '../../../utils';
+import {parseAndGetExpression} from '../../../utils';
 import {expect} from 'chai';
 
 describe('UnaryExpression', () => {
@@ -43,7 +43,7 @@ describe('UnaryExpression', () => {
     });
 
     it('should accept delete', () => {
-        var assignment = parseLooseAndGetExpression('delete x');
+        var assignment = parseAndGetExpression('delete x', 'loose');
         expect(assignment.operator).to.equal('delete');
         expect(assignment.argument.name).to.equal('x');
     });

--- a/test/lib/elements/types/UnaryExpression.js
+++ b/test/lib/elements/types/UnaryExpression.js
@@ -1,4 +1,4 @@
-import {parseAndGetExpression} from '../../../utils';
+import {parseAndGetExpression, parseLooseAndGetExpression} from '../../../utils';
 import {expect} from 'chai';
 
 describe('UnaryExpression', () => {
@@ -43,7 +43,7 @@ describe('UnaryExpression', () => {
     });
 
     it('should accept delete', () => {
-        var assignment = parseAndGetExpression('delete x');
+        var assignment = parseLooseAndGetExpression('delete x');
         expect(assignment.operator).to.equal('delete');
         expect(assignment.argument.name).to.equal('x');
     });

--- a/test/lib/elements/types/WithStatement.js
+++ b/test/lib/elements/types/WithStatement.js
@@ -1,13 +1,13 @@
-import {parseAndGetStatement} from '../../../utils';
+import {parseLooseAndGetStatement} from '../../../utils';
 import {expect} from 'chai';
 
 describe('WithStatement', () => {
     it('should return correct type', () => {
-        expect(parseAndGetStatement('with(true);').type).to.equal('WithStatement');
+        expect(parseLooseAndGetStatement('with(true);').type).to.equal('WithStatement');
     });
 
     it('should accept single statement', () => {
-        var statement = parseAndGetStatement('with (true) x;');
+        var statement = parseLooseAndGetStatement('with (true) x;');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('ExpressionStatement');
@@ -16,7 +16,7 @@ describe('WithStatement', () => {
     });
 
     it('should accept expression in parentheses', () => {
-        var statement = parseAndGetStatement('with ((true)) x;');
+        var statement = parseLooseAndGetStatement('with ((true)) x;');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('ExpressionStatement');
@@ -25,7 +25,7 @@ describe('WithStatement', () => {
     });
 
     it('should accept whitespaces', () => {
-        var statement = parseAndGetStatement('with ( true ) x ;');
+        var statement = parseLooseAndGetStatement('with ( true ) x ;');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('ExpressionStatement');
@@ -34,7 +34,7 @@ describe('WithStatement', () => {
     });
 
     it('should accept blocks', () => {
-        var statement = parseAndGetStatement('with ( true ) { x; }');
+        var statement = parseLooseAndGetStatement('with ( true ) { x; }');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('BlockStatement');

--- a/test/lib/elements/types/WithStatement.js
+++ b/test/lib/elements/types/WithStatement.js
@@ -1,13 +1,13 @@
-import {parseLooseAndGetStatement} from '../../../utils';
+import {parseAndGetStatement} from '../../../utils';
 import {expect} from 'chai';
 
 describe('WithStatement', () => {
     it('should return correct type', () => {
-        expect(parseLooseAndGetStatement('with(true);').type).to.equal('WithStatement');
+        expect(parseAndGetStatement('with(true);', 'loose').type).to.equal('WithStatement');
     });
 
     it('should accept single statement', () => {
-        var statement = parseLooseAndGetStatement('with (true) x;');
+        var statement = parseAndGetStatement('with (true) x;', 'loose');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('ExpressionStatement');
@@ -16,7 +16,7 @@ describe('WithStatement', () => {
     });
 
     it('should accept expression in parentheses', () => {
-        var statement = parseLooseAndGetStatement('with ((true)) x;');
+        var statement = parseAndGetStatement('with ((true)) x;', 'loose');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('ExpressionStatement');
@@ -25,7 +25,7 @@ describe('WithStatement', () => {
     });
 
     it('should accept whitespaces', () => {
-        var statement = parseLooseAndGetStatement('with ( true ) x ;');
+        var statement = parseAndGetStatement('with ( true ) x ;', 'loose');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('ExpressionStatement');
@@ -34,7 +34,7 @@ describe('WithStatement', () => {
     });
 
     it('should accept blocks', () => {
-        var statement = parseLooseAndGetStatement('with ( true ) { x; }');
+        var statement = parseAndGetStatement('with ( true ) { x; }', 'loose');
         expect(statement.object.type).to.equal('Literal');
         expect(statement.object.value).to.equal(true);
         expect(statement.body.type).to.equal('BlockStatement');

--- a/test/utils.js
+++ b/test/utils.js
@@ -11,9 +11,21 @@ export function parseAndGetStatement(code) {
     return program.body[0];
 }
 
+export function parseLooseAndGetStatement(code) {
+    var parser = new Parser();
+    var program = parser.parse(code, 'loose');
+    return program.body[0];
+}
+
 export function parseAndGetExpression(code) {
     var parser = new Parser();
     var program = parser.parse('(' + code + ')');
+    return program.body[0].expression;
+}
+
+export function parseLooseAndGetExpression(code) {
+    var parser = new Parser();
+    var program = parser.parse('(' + code + ')', 'loose');
     return program.body[0].expression;
 }
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -1,31 +1,19 @@
 import Parser from '../lib/Parser';
 
-export function parseAndGetProgram(code) {
+export function parseAndGetProgram(code, mode) {
     var parser = new Parser();
-    return parser.parse(code);
+    return parser.parse(code, mode);
 }
 
-export function parseAndGetStatement(code) {
+export function parseAndGetStatement(code, mode) {
     var parser = new Parser();
-    var program = parser.parse(code);
+    var program = parser.parse(code, mode);
     return program.body[0];
 }
 
-export function parseLooseAndGetStatement(code) {
+export function parseAndGetExpression(code, mode) {
     var parser = new Parser();
-    var program = parser.parse(code, 'loose');
-    return program.body[0];
-}
-
-export function parseAndGetExpression(code) {
-    var parser = new Parser();
-    var program = parser.parse('(' + code + ')');
-    return program.body[0].expression;
-}
-
-export function parseLooseAndGetExpression(code) {
-    var parser = new Parser();
-    var program = parser.parse('(' + code + ')', 'loose');
+    var program = parser.parse('(' + code + ')', mode);
     return program.body[0].expression;
 }
 


### PR DESCRIPTION
WIP: Lots of failling tests.

At first I just did `import {parse} from 'babel-core';` but then it would all be acorn stuff so I figured the 'parser' in babel-jscs could work to convert using `acorn-to-esprima` - https://github.com/jscs-dev/babel-jscs/blob/53cb7bdaa0e80d106f2384e2d9ecc8a1715e2b31/index.js#L88-L135

There's probably a few issues to fix here. Probably want to move `acorn-to-esprima` to new repo too. https://github.com/babel/babel-eslint/issues/24